### PR TITLE
Update build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -37,7 +37,8 @@ def create_batch_for_gui(release_dir: Path, exe_name: str):
     with open(batch_file_path, "w") as f:
         f.write("@echo off\n")
         f.write('cd /d "%~dp0"\n')
-        f.write(f'start "" {exe_name} --gui')
+        f.write(f'{exe_name} --gui\n')
+        f.write(f'start "" {exe_name}\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As d4lf doesn't update changes "on the fly", I think everybody's behaviour is: after setting up in GUI, start the main program. 
So this is my proposed change:
From now on, after "d4lf.exe --gui" closes, it will automatically start the main d4lf.exe. Try it yourself with this batch script:

@echo off
cd /d "%~dp0"
d4lf.exe --gui
start "" d4lf.exe